### PR TITLE
Add real-time scrub preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# mpv-screenshot
+
+Utility scripts for mpv.
+
+## preview.lua
+
+`preview.lua` shows every video frame while you scrub through the
+timeline. It listens for `time-pos` property changes and overlays the
+current frame so no frames are missed.
+
+### Key binding
+
+* **Ctrl+Shift+o** – Toggle scrub preview on or off. Bind it to another
+  key in `input.conf` if desired.
+
+### Usage
+
+Copy `preview.lua` into your `~/.config/mpv/scripts/` directory and
+restart mpv. Toggle preview with the key binding above, then scrub using
+the mouse or arrow keys to see each frame appear in an overlay.

--- a/preview.lua
+++ b/preview.lua
@@ -1,0 +1,31 @@
+-- preview.lua
+-- Display every video frame when scrubbing.
+-- Toggle with Ctrl+Shift+o (change in input.conf if needed).
+-- Uses screenshot-to-file and overlay-add to show current frame.
+
+local utils = require 'mp.utils'
+
+local tmpdir = os.getenv('TMPDIR') or os.getenv('TEMP') or os.getenv('TMP') or '/tmp'
+local tmpfile = utils.join_path(tmpdir, 'mpv_preview.png')
+local preview_enabled = false
+local overlay_id = 99
+
+local function show_frame(_, pos)
+    if not preview_enabled or not pos then return end
+    mp.commandv('screenshot-to-file', tmpfile, 'video')
+    mp.command_native({ name = 'overlay-add', id = overlay_id, x = 0, y = 0, file = tmpfile })
+end
+
+local function toggle_preview()
+    preview_enabled = not preview_enabled
+    if preview_enabled then
+        mp.observe_property('time-pos', 'native', show_frame)
+        mp.osd_message('Scrub preview ON')
+    else
+        mp.unobserve_property(show_frame)
+        mp.command_native({ name = 'overlay-remove', id = overlay_id })
+        mp.osd_message('Scrub preview OFF')
+    end
+end
+
+mp.add_key_binding('Ctrl+Shift+o', 'toggle-scrub-preview', toggle_preview)


### PR DESCRIPTION
## Summary
- add `preview.lua` to show frames when scrubbing
- document new script and key binding in README

## Testing
- `luac -p preview.lua` *(fails: `luac` not found)*