### PR TITLE
Add playback speed cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ current frame so no frames are missed.
 Copy `preview.lua` into your `~/.config/mpv/scripts/` directory and
 restart mpv. Toggle preview with the key binding above, then scrub using
 the mouse or arrow keys to see each frame appear in an overlay.
+
+## speedcycle.lua
+
+`speedcycle.lua` lets you cycle through preset playback speeds using simple keybinds.
+
+### Key bindings
+
+* **Ctrl+Shift+l** – Increase speed through 2x, 4x, 8x, 10x, 15x and 20x.
+* **Ctrl+Shift+k** – Step back down toward normal speed.
+
+### Usage
+
+Copy `speedcycle.lua` into your `~/.config/mpv/scripts/` directory. Use the keys above to quickly change playback speed in steps.
+

--- a/speedcycle.lua
+++ b/speedcycle.lua
@@ -1,0 +1,38 @@
+-- speedcycle.lua
+-- Cycle through playback speeds with key presses.
+-- Increase speed with 'l', decrease with 'k'.
+-- Speeds: 2x, 4x, 8x, 10x, 15x, 20x. Defaults to normal speed.
+
+local speeds = {2, 4, 8, 10, 15, 20}
+local index = 0 -- 0 means normal speed (1x)
+
+local function apply_speed()
+    if index == 0 then
+        mp.set_property_number('speed', 1)
+    else
+        mp.set_property_number('speed', speeds[index])
+    end
+    local spd = mp.get_property('speed')
+    mp.osd_message(('Speed: %sx'):format(spd))
+end
+
+local function speed_up()
+    if index < #speeds then
+        index = index + 1
+        apply_speed()
+    else
+        mp.osd_message('Speed: ' .. speeds[#speeds] .. 'x')
+    end
+end
+
+local function speed_down()
+    if index > 0 then
+        index = index - 1
+        apply_speed()
+    else
+        mp.osd_message('Speed: 1x')
+    end
+end
+
+mp.add_key_binding('Ctrl+Shift+l', 'speed-up-cycle', speed_up)
+mp.add_key_binding('Ctrl+Shift+k', 'speed-down-cycle', speed_down)


### PR DESCRIPTION
## Summary
- add `speedcycle.lua` to change playback speed through preset steps
- document usage and keybinds for `speedcycle.lua`
- update keybinds to use `Ctrl+Shift+l` and `Ctrl+Shift+k` to avoid mpv defaults

## Testing
- `lua -v` *(fails: command not found)*