### PR TITLE
Fix speed cycle bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ the mouse or arrow keys to see each frame appear in an overlay.
 
 ### Key bindings
 
+* **Ctrl+Shift+Up** – Increase speed through 2x, 4x, 8x, 10x, 15x and 20x.
+* **Ctrl+Shift+Down** – Step back down toward normal speed.
 
 ### Usage
 

--- a/speedcycle.lua
+++ b/speedcycle.lua
@@ -1,6 +1,6 @@
 -- speedcycle.lua
 -- Cycle through playback speeds with key presses.
--- Increase speed with 'l', decrease with 'k'.
+-- Increase speed with Ctrl+Shift+Up, decrease with Ctrl+Shift+Down.
 -- Speeds: 2x, 4x, 8x, 10x, 15x, 20x. Defaults to normal speed.
 
 local speeds = {2, 4, 8, 10, 15, 20}
@@ -34,4 +34,11 @@ local function speed_down()
     end
 end
 
+-- Default key bindings
+mp.add_key_binding('Ctrl+Shift+UP', 'speedcycle-up', speed_up)
+mp.add_key_binding('Ctrl+Shift+DOWN', 'speedcycle-down', speed_down)
+
+-- Allow custom bindings via script messages
+mp.register_script_message('speedcycle-up', speed_up)
+mp.register_script_message('speedcycle-down', speed_down)
 


### PR DESCRIPTION
## Summary
- restore missing key bindings in speedcycle.lua
- use `Ctrl+Shift+Up/Down` to avoid mpv's built-in `l`/`k` actions
- document the new keys in the README

## Testing
- `echo "No automated tests available." && true`